### PR TITLE
Set React components' foreground to be different from HTML tags

### DIFF
--- a/themes/yume-mode-dark.json
+++ b/themes/yume-mode-dark.json
@@ -292,12 +292,18 @@
                 "foreground": "#DBDBDD"
             }
         },
-
         {
             "name": "HTML tags",
             "scope": ["entity.name.tag"],
             "settings": {
                 "foreground": "#EF83B0"
+            }
+        },
+        {
+            "name": "React components (.jsx, .tsx)",
+            "scope": ["support.class.component.js.jsx", "support.class.component.tsx"],
+            "settings": {
+                "foreground": "#CAB4EC"
             }
         },
         {


### PR DESCRIPTION
This pull request resolves the problem of React components and HTML tags sharing the same foreground as mentioned in #1.